### PR TITLE
fix .end() calling store.end() multiple times on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,13 +69,15 @@ Storage.prototype._readMulti = function (offset, length, next, cb) {
 Storage.prototype._end = function (opts, cb) {
   var self = this
 
-  next(0)
+  next()
 
-  function next (i) {
-    if (!self.stores[i]) return cb()
-    self.stores[i].storage.end(opts, function (err) {
+  function next () {
+    var store = self.stores[0]
+    if (!store) return process.nextTick(cb)
+    store.storage.end(opts, function (err) {
       if (err) return cb(err)
-      next(i + 1)
+      self.stores.shift()
+      next()
     })
   }
 }
@@ -83,13 +85,15 @@ Storage.prototype._end = function (opts, cb) {
 Storage.prototype._close = function (cb) {
   var self = this
 
-  next(0)
+  next()
 
-  function next (i) {
-    if (!self.stores[i]) return cb()
-    self.stores[i].storage.close(function (err) {
+  function next () {
+    var store = self.stores[0]
+    if (!store) return process.nextTick(cb)
+    store.storage.close(function (err) {
       if (err) return cb(err)
-      next(i + 1)
+      self.stores.shift()
+      next()
     })
   }
 }

--- a/test.js
+++ b/test.js
@@ -120,3 +120,85 @@ test('end', function (t) {
     t.error(err)
   })
 })
+
+test('end retries', function (t) {
+  t.plan(5)
+
+  var storage = Storage()
+  var childStorage = ram(new Buffer(10))
+  var i = 0
+  childStorage._end = function (opts, cb) {
+    t.ok(true)
+    if (i++ === 1) return cb(new Error('nope'))
+    cb()
+  }
+  storage.add({
+    start: 0,
+    end: 9,
+    storage: childStorage
+  })
+  storage.add({
+    start: 10,
+    end: 19,
+    storage: childStorage
+  })
+  storage.end(function (err) {
+    t.ok(err)
+    storage.end(function (err) {
+      t.error(err)
+    })
+  })
+})
+
+test('close', function (t) {
+  t.plan(3)
+
+  var storage = Storage()
+  var childStorage = ram(new Buffer(10))
+  childStorage._close = function (cb) {
+    t.ok(true)
+    cb()
+  }
+  storage.add({
+    start: 0,
+    end: 9,
+    storage: childStorage
+  })
+  storage.add({
+    start: 10,
+    end: 19,
+    storage: childStorage
+  })
+  storage.close(function (err) {
+    t.error(err)
+  })
+})
+
+test('close retries', function (t) {
+  t.plan(5)
+
+  var storage = Storage()
+  var childStorage = ram(new Buffer(10))
+  var i = 0
+  childStorage._close = function (cb) {
+    t.ok(true)
+    if (i++ === 1) return cb(new Error('nope'))
+    cb()
+  }
+  storage.add({
+    start: 0,
+    end: 9,
+    storage: childStorage
+  })
+  storage.add({
+    start: 10,
+    end: 19,
+    storage: childStorage
+  })
+  storage.close(function (err) {
+    t.ok(err)
+    storage.close(function (err) {
+      t.error(err)
+    })
+  })
+})


### PR DESCRIPTION
remove a store from the `.stores` array if it has been closed successfully, so if you need to retry the `.end()` call a `store.end()` isn't going to be called although it has already been ended.

if this gets merged, i can do the same for .close()
